### PR TITLE
Bump API version to V4

### DIFF
--- a/src/dv360.ts
+++ b/src/dv360.ts
@@ -84,7 +84,7 @@ export class DV360 extends ApiClient {
    */
   constructor(
     authToken: string,
-    dv360BaseUrl = 'https://displayvideo.googleapis.com/v2'
+    dv360BaseUrl = 'https://displayvideo.googleapis.com/v4'
   ) {
     super(dv360BaseUrl, authToken);
   }
@@ -249,7 +249,7 @@ export class DV360 extends ApiClient {
     //url doesn't contain version, just /media/
     const downloadMediaUrl = this.getUrl(
       `download/${resourceName}?alt=media`
-    ).replace('/v2', '');
+    ).replace('/v4', '');
     const downloadMedia = this.fetchBlob(downloadMediaUrl);
     //TODO move somewhere else afterwards
     downloadMedia.setContentType('application/zip');


### PR DESCRIPTION
Bumping the DV360 API version to V4 (as V2 is obsolete) - manual testing shows that this solution isn't affected by any of the breaking changes between V2 and V4 :) 